### PR TITLE
improve container build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,7 @@
+.*ignore
 .git
+.gitattributes
+*.md
 coverage
 build
 node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.17.8-alpine3.15
+FROM docker.io/library/golang:1.17.8-alpine3.15
 WORKDIR /build
-RUN apk update
-RUN apk add --update --no-cache nodejs npm git make python3 gcc musl-dev linux-headers bash
-RUN npm i -g yarn
-ADD ./package.json /build/package.json
-RUN yarn || true
-ADD . /build
+RUN apk upgrade --no-cache \
+    && apk add --no-cache \
+    nodejs npm yarn git make python2 python3 g++ musl-dev linux-headers bash
+COPY package.json yarn.lock ./
+RUN yarn
+COPY . ./
 RUN yarn compile
 RUN go build -o /build/create-genesis ./
 ENTRYPOINT ["/build/create-genesis"]


### PR DESCRIPTION
Building the container worked for me in the past but failed today. Adding the `yarn.lock` to the container solved that problem for me.

I also improved the build in general:

- fully specified base image to build with podman
- install yarn via apk (known version rather than latest)
- install dependencies which were stated missing on running `yarn` (python2, g++)
- ensure all apk packages are up to date rather than just the specified ones (`apk add --update` → `apk upgrade`)
- adding more `.dockerignore` entries